### PR TITLE
feat: specify position of the heading anchor

### DIFF
--- a/assets/plugin.css
+++ b/assets/plugin.css
@@ -1,18 +1,28 @@
 a.plugin-anchor {
-  color: inherit !important;
+  color: inherit;
   display: none;
-  margin-left: -30px;
-  padding-left: 40px;
   cursor: pointer;
   position: absolute;
+}
+
+a.plugin-anchor--before {
+  margin-left: -30px;
+  padding-left: 40px;
   top: 0;
   left: 0;
   bottom: 0;
 }
 
 a.plugin-anchor i {
+  font-size: 16px !important;
+}
+
+a.plugin-anchor--before i {
   margin-left: -30px;
-  font-size: 15px !important;
+}
+
+a.plugin-anchor--after i {
+  margin-left: 8px;
 }
 
 h1,

--- a/package.json
+++ b/package.json
@@ -21,5 +21,12 @@
     "eslint": "^7.22.0",
     "eslint-config-prettier": "^8.1.0",
     "prettier": "^2.2.1"
+  },
+  "honkit": {
+    "properties": {
+      "anchors": {
+        "position": "before"
+      }
+    }
   }
 }


### PR DESCRIPTION
## Why

[Gitbook Anchors Plugin](https://github.com/rlmv/gitbook-plugin-anchors) adds a heading anchor to the front of the header.
In some cases, an anchor is added behind the header.

## What

The position of the heading anchor is specified in `pluginConfig`.

```json
{
  "pluginsConfig": {
    "anchors": {
      "position": "after"
    }
  }
}
```